### PR TITLE
Remove `version_compare`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_ver
 
 # Flag that selects if systemd or upstart will be used for the init service:
 # Note: by default Ubuntu 15.04 and later use systemd (but support switch to upstart)
-zookeeper_debian_systemd_enabled: "{{ ansible_distribution_version is version_compare(15.04, '>=') }}"
+zookeeper_debian_systemd_enabled: "{{ ansible_distribution_version is version(15.04, '>=') }}"
 zookeeper_debian_apt_install: false
 # (Optional:) add custom 'ppa' repositories depending on the distro version (only with debian_apt_install=true)
 # Example: to use a community zookeeper v3.4.8 deb pkg for Ubuntu 14.04 (where latest official is v3.4.5)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,8 +4,8 @@ zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_ver
 
 # Flag that selects if systemd or upstart will be used for the init service:
 # Note: by default Ubuntu 15.04 and later use systemd (but support switch to upstart)
-_ubuntu_1504: "{{ ansible_distribution == 'Ubuntu' and ansible_distribution_version is version_compare(15.04, '>=') }}"
-_debian_8: "{{ ansible_distribution == 'Debian' and ansible_distribution_version is version_compare(8.0, '>=') }}"
+_ubuntu_1504: "{{ ansible_distribution == 'Ubuntu' and ansible_distribution_version is version(15.04, '>=') }}"
+_debian_8: "{{ ansible_distribution == 'Debian' and ansible_distribution_version is version(8.0, '>=') }}"
 zookeeper_debian_systemd_enabled: "{{ _ubuntu_1504 or _debian_8 }}"
 
 zookeeper_debian_apt_install: false

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add optional custom apt repositories (for additional zookeeper versions)
   apt_repository: repo={{item.repository_url}} state=present
-  when: "{{ ansible_distribution_version is version_compare(item.distro_version, item.version_comparator|default('=')) }}"
+  when: "{{ ansible_distribution_version is version(item.distro_version, item.version_comparator|default('=')) }}"
   with_items:
     - "{{ zookeeper_debian_apt_repositories }}"
 


### PR DESCRIPTION
Replacing deprecated `version_compare` with `version`. See [here](https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html#comparing-versions) for more.